### PR TITLE
Fix Telnyx call control stream_start timing

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,8 +1,14 @@
 import argparse
+import asyncio
 import os
 import time
+from typing import Any, Dict, Optional
+from urllib.parse import quote
+
+import httpx
 from fastapi import FastAPI, HTTPException, Request, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
+from loguru import logger
 from starlette.responses import HTMLResponse, JSONResponse
 from dotenv import load_dotenv
 
@@ -10,6 +16,16 @@ load_dotenv(override=True)
 
 app = FastAPI()
 app.state.start_ts = time.time()
+app.state.telnyx_stream_started: set[str] = set()
+
+PUBLIC_URL = os.getenv("PUBLIC_URL", "").strip()
+TELEPHONY_WS_URL = os.getenv("TELEPHONY_WS_URL", "").strip()
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY", "").strip()
+TELNYX_API_BASE_URL = os.getenv("TELNYX_API_BASE_URL", "https://api.telnyx.com/v2").rstrip("/")
+TELNYX_STREAM_TRACK = (os.getenv("TELNYX_STREAM_TRACK", "both") or "both").strip() or "both"
+TELNYX_STREAM_TYPE = (os.getenv("TELNYX_STREAM_TYPE", "audio") or "audio").strip() or "audio"
+TELNYX_AUTO_ANSWER = os.getenv("TELNYX_AUTO_ANSWER", "true").lower() not in {"false", "0", "no"}
+TELNYX_TIMEOUT = httpx.Timeout(10.0)
 
 # Konfigurierbare Ready-Verzögerung (Sekunden), um Kaltstart abzufangen
 READY_DELAY_SEC = float(os.getenv("TWI_ML_READY_DELAY_SEC", "3"))
@@ -23,12 +39,29 @@ app.add_middleware(
 )
 
 
-def _get_ws_url(host: str) -> str:
+def _get_ws_url(host: Optional[str]) -> str:
+    if TELEPHONY_WS_URL:
+        return TELEPHONY_WS_URL
+
+    base = PUBLIC_URL
     env = os.getenv("ENV", "local").lower()
-    if env == "production":
-        # Pipecat Cloud Pfad; lokal nutzen wir unseren eigenen WS
-        return "wss://api.pipecat.daily.co/ws/twilio"
-    return f"wss://{host}/ws"
+    if not base:
+        if not host:
+            raise HTTPException(status_code=400, detail="Host-Header fehlt")
+        scheme = "http" if env == "local" else "https"
+        base = f"{scheme}://{host}"
+
+    base = base.rstrip("/")
+    if base.startswith("ws://") or base.startswith("wss://"):
+        ws_base = base
+    elif base.startswith("http://"):
+        ws_base = "ws://" + base[len("http://") :]
+    elif base.startswith("https://"):
+        ws_base = "wss://" + base[len("https://") :]
+    else:
+        ws_base = f"wss://{base.lstrip('/')}"
+
+    return f"{ws_base}/ws"
 
 
 def _build_parameters(from_number: str, to_number: str) -> list[str]:
@@ -49,7 +82,7 @@ def _build_parameters(from_number: str, to_number: str) -> list[str]:
     return params
 
 
-def _twiml(host: str, from_number: str, to_number: str) -> str:
+def _twiml(host: Optional[str], from_number: str, to_number: str) -> str:
     ws = _get_ws_url(host)
     params = "\n      ".join(_build_parameters(from_number, to_number))
     return f"""<?xml version="1.0" encoding="UTF-8"?>
@@ -73,28 +106,169 @@ def _twiml_wait_and_redirect() -> str:
 </Response>"""
 
 
+def _extract_request_host(request: Request) -> Optional[str]:
+    return request.headers.get("x-forwarded-host") or request.headers.get("host")
+
+
+def _is_telnyx_request(request: Request) -> bool:
+    content_type = (request.headers.get("content-type") or "").lower()
+    if request.headers.get("telnyx-signature-ed25519"):
+        return True
+    return "application/json" in content_type
+
+
+async def _telnyx_call_control_action(
+    call_control_id: str,
+    action: str,
+    payload: Optional[Dict[str, Any]] = None,
+) -> bool:
+    if not TELNYX_API_KEY:
+        logger.warning(
+            "Telnyx-Aktion {} übersprungen: TELNYX_API_KEY ist nicht gesetzt.",
+            action,
+        )
+        return False
+
+    encoded_call_control_id = quote(str(call_control_id), safe="")
+    url = f"{TELNYX_API_BASE_URL}/calls/{encoded_call_control_id}/actions/{action}"
+    headers = {
+        "Authorization": f"Bearer {TELNYX_API_KEY}",
+        "Content-Type": "application/json",
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=TELNYX_TIMEOUT) as client:
+            response = await client.post(url, json=payload or {}, headers=headers)
+    except httpx.HTTPError as exc:
+        logger.exception("Telnyx-Aktion {} fehlgeschlagen: {}", action, exc)
+        return False
+
+    if response.status_code >= 300:
+        logger.error(
+            "Telnyx-Aktion {} fehlgeschlagen ({}): {}",
+            action,
+            response.status_code,
+            response.text,
+        )
+        return False
+
+    return True
+
+
+async def _telnyx_start_stream(payload: Dict[str, Any], host: Optional[str]) -> None:
+    call_control_id = payload.get("call_control_id")
+    if not call_control_id:
+        logger.warning("Telnyx-Event ohne call_control_id: {}", payload)
+        return
+
+    started_set = getattr(app.state, "telnyx_stream_started", set())
+    if call_control_id in started_set:
+        logger.debug("Telnyx-Stream für {} wurde bereits angefordert", call_control_id)
+        return
+
+    try:
+        ws_url = _get_ws_url(host)
+    except HTTPException as exc:
+        logger.error(
+            "Telnyx-Stream kann nicht gestartet werden: {}",
+            exc.detail if hasattr(exc, "detail") else exc,
+        )
+        return
+
+    logger.info("Starte Telnyx-Stream {} -> {}", call_control_id, ws_url)
+
+    stream_payload: Dict[str, Any] = {
+        "stream_url": ws_url,
+        "stream_track": TELNYX_STREAM_TRACK,
+        "stream_type": TELNYX_STREAM_TYPE,
+    }
+    started = await _telnyx_call_control_action(
+        call_control_id,
+        "stream_start",
+        stream_payload,
+    )
+    if started:
+        started_set.add(call_control_id)
+
 @app.get("/health")
 async def health():
-    return JSONResponse({"ok": True, "service": "pipecat-twilio-gemini"})
+    return JSONResponse(
+        {
+            "ok": True,
+            "service": "pipecat-telephony-gemini",
+            "providers": [
+                provider
+                for provider in ["telnyx" if TELNYX_API_KEY else None, "twilio"]
+                if provider
+            ],
+        }
+    )
 
 
-@app.post("/")
-async def twilio_webhook(request: Request):
+async def _handle_twilio_webhook(request: Request) -> HTMLResponse:
     form = await request.form()
-    call_sid = form.get("CallSid", "")
     from_number = form.get("From", "")
     to_number = form.get("To", "")
 
-    host = request.headers.get("host")
-    if not host:
+    host = _extract_request_host(request)
+    if not host and not (PUBLIC_URL or TELEPHONY_WS_URL):
         raise HTTPException(status_code=400, detail="Host-Header fehlt")
 
-    # Health-Gate: innerhalb der ersten READY_DELAY_SEC Sekunden nur warten/redirecten
     if (time.time() - app.state.start_ts) < READY_DELAY_SEC:
         xml = _twiml_wait_and_redirect()
     else:
         xml = _twiml(host, from_number, to_number)
     return HTMLResponse(content=xml, media_type="application/xml")
+
+
+async def _handle_telnyx_webhook(request: Request) -> JSONResponse:
+    try:
+        payload = await request.json()
+    except Exception as exc:
+        logger.exception("Telnyx-Webhook konnte nicht geparst werden: {}", exc)
+        raise HTTPException(status_code=400, detail="Ungültiges JSON von Telnyx")
+
+    data = payload.get("data") or {}
+    event_type = data.get("event_type") or payload.get("event_type")
+    event_payload: Dict[str, Any] = data.get("payload") or {}
+    call_control_id = event_payload.get("call_control_id")
+
+    logger.info(
+        "Telnyx-Webhook: {} (call_control_id: {})",
+        event_type,
+        call_control_id,
+    )
+
+    host = _extract_request_host(request)
+
+    if event_type == "call.initiated":
+        if TELNYX_AUTO_ANSWER:
+            if call_control_id:
+                asyncio.create_task(
+                    _telnyx_call_control_action(call_control_id, "answer")
+                )
+            else:
+                logger.warning(
+                    "Telnyx call.initiated ohne call_control_id: {}", payload
+                )
+    elif event_type == "call.answered":
+        asyncio.create_task(_telnyx_start_stream(event_payload, host))
+    elif event_type == "call.hangup":
+        logger.info("Telnyx-Hangup erhalten für {}", call_control_id)
+        getattr(app.state, "telnyx_stream_started", set()).discard(call_control_id)
+    elif event_type:
+        logger.debug("Telnyx-Event {} empfangen", event_type)
+    else:
+        logger.warning("Telnyx-Event ohne event_type: {}", payload)
+
+    return JSONResponse({"data": {"result": "ok"}})
+
+
+@app.post("/")
+async def telephony_webhook(request: Request):
+    if _is_telnyx_request(request):
+        return await _handle_telnyx_webhook(request)
+    return await _handle_twilio_webhook(request)
 
 
 @app.websocket("/ws")


### PR DESCRIPTION
## Summary
- add Telnyx-aware configuration to the booking client and prompt handling, including per-provider phone instructions and audio encoding normalization
- extend the telephony runner to auto-detect Telnyx WebSocket payloads, instantiate the Telnyx frame serializer, and switch Gemini to the gemini-live-2.5-flash-preview model
- refactor the FastAPI server so the root webhook supports both Telnyx JSON events and Twilio form posts, answering Telnyx calls, waiting for call.answered before issuing stream_start, URL-encoding call control IDs, and tracking stream state to avoid duplicate starts

## Testing
- python -m compileall bot.py server.py

------
https://chatgpt.com/codex/tasks/task_e_68cbfd288aa4832d87380a9c1b00b72d